### PR TITLE
50/animation controls

### DIFF
--- a/src/components/common/AnimationControls.js
+++ b/src/components/common/AnimationControls.js
@@ -6,8 +6,10 @@ import IconButton from '@material-ui/core/IconButton';
 import PauseCircleOutlineIcon from '@material-ui/icons/PauseCircleOutline';
 import PlayCircleOutlineIcon from '@material-ui/icons/PlayCircleOutline';
 import RotateLeftIcon from '@material-ui/icons/RotateLeft';
+import StopIcon from '@material-ui/icons/Stop';
 import Tooltip from '@material-ui/core/Tooltip';
-import { green, red, yellow } from '@material-ui/core/colors';
+import { green, red, blue, yellow } from '@material-ui/core/colors';
+import clsx from 'clsx';
 import {
   togglePause,
   toggleOscillation,
@@ -26,10 +28,18 @@ import {
 } from '../../config/constants';
 
 const useStyles = makeStyles(() => ({
+  buttonContainer: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
+  button: {
+    fontSize: '1.75em',
+  },
   pauseButton: {
     color: yellow[800],
   },
   playButton: { color: green[800] },
+  stopButton: { color: blue[900] },
   resetButton: { color: red[800] },
 }));
 
@@ -42,8 +52,23 @@ const AnimationControls = () => {
   );
   const dispatch = useDispatch();
 
-  const onClickPauseOrPlay = () => {
-    dispatch(togglePause(!isPaused));
+  const onClickPlay = () => {
+    dispatch(togglePause(false));
+    dispatch(toggleOscillation(true));
+  };
+
+  const onClickPause = () => {
+    dispatch(togglePause(true));
+    dispatch(toggleOscillation(false));
+  };
+
+  const onClickStop = () => {
+    dispatch(setTimerCount(DEFAULT_TIMER_COUNT));
+    dispatch(setElapsedTime(DEFAULT_ELAPSED_TIME));
+    dispatch(toggleOscillation(false));
+    dispatch(togglePause(true));
+    dispatch(toggleMeasuringArrow(false));
+    dispatch(toggleSpectrumBar(false));
   };
 
   const onClickReset = () => {
@@ -62,36 +87,41 @@ const AnimationControls = () => {
     dispatch(setTimerCount(DEFAULT_TIMER_COUNT));
     dispatch(setElapsedTime(DEFAULT_ELAPSED_TIME));
     dispatch(toggleOscillation(false));
-    dispatch(togglePause(false));
+    dispatch(togglePause(true));
     dispatch(toggleMeasuringArrow(false));
     dispatch(toggleSpectrumBar(false));
   };
 
   return (
-    <div>
+    <div className={classes.buttonContainer}>
       {!isPaused && (
         <Tooltip title={t('Pause')}>
-          <IconButton onClick={onClickPauseOrPlay}>
+          <IconButton onClick={onClickPause}>
             <PauseCircleOutlineIcon
-              className={classes.pauseButton}
-              fontSize="large"
+              className={clsx(classes.button, classes.pauseButton)}
             />
           </IconButton>
         </Tooltip>
       )}
       {isPaused && (
         <Tooltip title={t('Play')}>
-          <IconButton onClick={onClickPauseOrPlay}>
+          <IconButton onClick={onClickPlay}>
             <PlayCircleOutlineIcon
-              className={classes.playButton}
-              fontSize="large"
+              className={clsx(classes.button, classes.playButton)}
             />
           </IconButton>
         </Tooltip>
       )}
+      <Tooltip title={t('Stop')}>
+        <IconButton onClick={onClickStop}>
+          <StopIcon className={clsx(classes.button, classes.stopButton)} />
+        </IconButton>
+      </Tooltip>
       <Tooltip title={t('Reset')}>
         <IconButton onClick={onClickReset}>
-          <RotateLeftIcon className={classes.resetButton} fontSize="large" />
+          <RotateLeftIcon
+            className={clsx(classes.button, classes.resetButton)}
+          />
         </IconButton>
       </Tooltip>
     </div>

--- a/src/components/common/AnimationControls.js
+++ b/src/components/common/AnimationControls.js
@@ -8,7 +8,7 @@ import PlayCircleOutlineIcon from '@material-ui/icons/PlayCircleOutline';
 import RotateLeftIcon from '@material-ui/icons/RotateLeft';
 import StopIcon from '@material-ui/icons/Stop';
 import Tooltip from '@material-ui/core/Tooltip';
-import { green, red, blue, yellow } from '@material-ui/core/colors';
+import { green, orange, blue, yellow } from '@material-ui/core/colors';
 import clsx from 'clsx';
 import {
   togglePause,
@@ -40,7 +40,7 @@ const useStyles = makeStyles(() => ({
   },
   playButton: { color: green[800] },
   stopButton: { color: blue[900] },
-  resetButton: { color: red[800] },
+  resetButton: { color: orange[800] },
 }));
 
 const AnimationControls = () => {
@@ -67,8 +67,6 @@ const AnimationControls = () => {
     dispatch(setElapsedTime(DEFAULT_ELAPSED_TIME));
     dispatch(toggleOscillation(false));
     dispatch(togglePause(true));
-    dispatch(toggleMeasuringArrow(false));
-    dispatch(toggleSpectrumBar(false));
   };
 
   const onClickReset = () => {
@@ -95,7 +93,7 @@ const AnimationControls = () => {
   return (
     <div className={classes.buttonContainer}>
       {!isPaused && (
-        <Tooltip title={t('Pause')}>
+        <Tooltip title={t('Pause')} placement="left">
           <IconButton onClick={onClickPause}>
             <PauseCircleOutlineIcon
               className={clsx(classes.button, classes.pauseButton)}
@@ -104,7 +102,7 @@ const AnimationControls = () => {
         </Tooltip>
       )}
       {isPaused && (
-        <Tooltip title={t('Play')}>
+        <Tooltip title={t('Play')} placement="left">
           <IconButton onClick={onClickPlay}>
             <PlayCircleOutlineIcon
               className={clsx(classes.button, classes.playButton)}
@@ -112,12 +110,16 @@ const AnimationControls = () => {
           </IconButton>
         </Tooltip>
       )}
-      <Tooltip title={t('Stop')}>
-        <IconButton onClick={onClickStop}>
-          <StopIcon className={clsx(classes.button, classes.stopButton)} />
+      <Tooltip title={t('Stop')} placement="top">
+        <IconButton disabled={isPaused} onClick={onClickStop}>
+          <StopIcon
+            className={clsx(classes.button, {
+              [classes.stopButton]: !isPaused,
+            })}
+          />
         </IconButton>
       </Tooltip>
-      <Tooltip title={t('Reset')}>
+      <Tooltip title={t('Reset')} placement="right">
         <IconButton onClick={onClickReset}>
           <RotateLeftIcon
             className={clsx(classes.button, classes.resetButton)}

--- a/src/components/common/SideMenu.js
+++ b/src/components/common/SideMenu.js
@@ -11,7 +11,6 @@ import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import {
   toggleSideMenu,
-  toggleOscillation,
   toggleGridLines,
   toggleMeasuringArrow,
   toggleSpectrumBar,
@@ -59,13 +58,11 @@ class SideMenu extends React.Component {
     }).isRequired,
     t: PropTypes.func.isRequired,
     showSideMenu: PropTypes.bool.isRequired,
-    oscillation: PropTypes.bool.isRequired,
     spectrumBar: PropTypes.bool.isRequired,
     gridLines: PropTypes.bool.isRequired,
     measuringArrow: PropTypes.bool.isRequired,
     dispatchToggleGridLines: PropTypes.func.isRequired,
     dispatchToggleMeasuringArrow: PropTypes.func.isRequired,
-    dispatchToggleOscillation: PropTypes.func.isRequired,
     dispatchToggleSideMenu: PropTypes.func.isRequired,
     dispatchToggleSpectrumBar: PropTypes.func.isRequired,
     dispatchSetAmplitude: PropTypes.func.isRequired,
@@ -100,11 +97,9 @@ class SideMenu extends React.Component {
     const {
       classes,
       showSideMenu,
-      oscillation,
       gridLines,
       measuringArrow,
       spectrumBar,
-      dispatchToggleOscillation,
       dispatchToggleSpectrumBar,
       dispatchToggleGridLines,
       dispatchToggleMeasuringArrow,
@@ -126,15 +121,8 @@ class SideMenu extends React.Component {
         >
           {this.renderDrawerHeader()}
           <div className={classes.contentWrapper}>
+            <AnimationControls />
             <LineSelector />
-            <div className={classes.switchContainer}>
-              <CustomSwitch
-                switchLabel={t('Oscillation')}
-                switchStatus={oscillation}
-                switchDispatch={dispatchToggleOscillation}
-              />
-              <AnimationControls />
-            </div>
             <div className={classes.switchContainer}>
               <CustomSwitch
                 switchLabel={t('Grid')}
@@ -168,7 +156,7 @@ class SideMenu extends React.Component {
 
 const mapStateToProps = ({ layout }) => ({
   showSideMenu: layout.showSideMenu,
-  oscillation: layout.lab.oscillation,
+
   gridLines: layout.lab.gridLines,
   measuringArrow: layout.lab.measuringArrow,
   spectrumBar: layout.lab.spectrumBar,
@@ -178,7 +166,6 @@ const mapDispatchToProps = {
   dispatchToggleSideMenu: toggleSideMenu,
   dispatchToggleGridLines: toggleGridLines,
   dispatchToggleMeasuringArrow: toggleMeasuringArrow,
-  dispatchToggleOscillation: toggleOscillation,
   dispatchToggleSpectrumBar: toggleSpectrumBar,
   dispatchSetFrequency: setFrequency,
   dispatchSetAmplitude: setAmplitude,

--- a/src/components/lab/EmittedLine.js
+++ b/src/components/lab/EmittedLine.js
@@ -32,7 +32,10 @@ export default class EmittedLine extends Component {
   };
 
   componentDidMount() {
-    this.beginLineInterval();
+    const { isPaused } = this.props;
+    if (!isPaused) {
+      this.beginLineInterval();
+    }
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/src/components/lab/EmittedLine.js
+++ b/src/components/lab/EmittedLine.js
@@ -4,6 +4,7 @@ import { Line } from 'react-konva';
 import _ from 'lodash';
 import {
   DEFAULT_TENSION,
+  DEFAULT_TIMER_COUNT,
   SET_INTERVAL_TIME,
   STROKE_COLOR,
 } from '../../config/constants';
@@ -29,27 +30,35 @@ export default class EmittedLine extends Component {
     }).isRequired,
     numberOfLines: PropTypes.number.isRequired,
     maxPointsForLines: PropTypes.number.isRequired,
+    oscillation: PropTypes.bool.isRequired,
+    timerCount: PropTypes.number.isRequired,
   };
 
   componentDidMount() {
-    const { isPaused } = this.props;
-    if (!isPaused) {
-      this.beginLineInterval();
-    }
+    this.beginLineInterval();
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { isPaused, numberOfLines } = this.props;
-    if (isPaused !== prevProps.isPaused && isPaused) {
+    const { isPaused, oscillation, timerCount, numberOfLines } = this.props;
+    if (isPaused !== prevProps.isPaused && isPaused && !oscillation) {
       clearInterval(this.emittedLineInterval);
-    } else if (isPaused !== prevProps.isPaused && !isPaused) {
+    } else if (isPaused !== prevProps.isPaused && !isPaused && oscillation) {
+      clearInterval(this.emittedLineInterval);
+      this.beginLineInterval();
+    }
+    if (
+      timerCount !== prevProps.timerCount &&
+      timerCount === DEFAULT_TIMER_COUNT
+    ) {
       this.beginLineInterval();
     }
     if (
       numberOfLines !== prevProps.numberOfLines &&
       !_.isEqual(prevState.points, EmittedLine.initialPoints)
     ) {
+      clearInterval(this.emittedLineInterval);
       this.resetLine();
+      this.beginLineInterval();
     }
   }
 

--- a/src/components/lab/EmittedLine.js
+++ b/src/components/lab/EmittedLine.js
@@ -40,18 +40,23 @@ export default class EmittedLine extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     const { isPaused, oscillation, timerCount, numberOfLines } = this.props;
-    if (isPaused !== prevProps.isPaused && isPaused && !oscillation) {
-      clearInterval(this.emittedLineInterval);
-    } else if (isPaused !== prevProps.isPaused && !isPaused && oscillation) {
-      clearInterval(this.emittedLineInterval);
-      this.beginLineInterval();
+    if (isPaused !== prevProps.isPaused) {
+      if (isPaused && !oscillation) {
+        clearInterval(this.emittedLineInterval);
+      }
+      if (!isPaused && oscillation) {
+        clearInterval(this.emittedLineInterval);
+        this.beginLineInterval();
+      }
     }
+
     if (
       timerCount !== prevProps.timerCount &&
       timerCount === DEFAULT_TIMER_COUNT
     ) {
       this.beginLineInterval();
     }
+
     if (
       numberOfLines !== prevProps.numberOfLines &&
       !_.isEqual(prevState.points, EmittedLine.initialPoints)

--- a/src/components/lab/Lab.js
+++ b/src/components/lab/Lab.js
@@ -9,7 +9,6 @@ import ChargeSymbol from './ChargeSymbol';
 import MeasuringArrow from './MeasuringArrow';
 import SpectrumBar from './SpectrumBar';
 import {
-  togglePause,
   setStageDimensions,
   setChargeOrigin,
   setChargeOscillation,
@@ -55,7 +54,6 @@ class Lab extends Component {
     numberOfLines: PropTypes.number.isRequired,
     frequency: PropTypes.number.isRequired,
     isPaused: PropTypes.bool.isRequired,
-    dispatchTogglePause: PropTypes.func.isRequired,
     timerCount: PropTypes.number.isRequired,
     elapsedTime: PropTypes.number.isRequired,
     dispatchSetChargeOscillation: PropTypes.func.isRequired,
@@ -77,6 +75,7 @@ class Lab extends Component {
     }).isRequired,
     measuringArrowWidth: PropTypes.number.isRequired,
     spectrumBar: PropTypes.bool.isRequired,
+    oscillation: PropTypes.bool.isRequired,
   };
 
   state = {
@@ -174,11 +173,6 @@ class Lab extends Component {
     }, SET_INTERVAL_TIME);
   };
 
-  handleCanvasClick = () => {
-    const { isPaused, dispatchTogglePause } = this.props;
-    dispatchTogglePause(!isPaused);
-  };
-
   // element position should consider header height
   render() {
     const {
@@ -194,6 +188,8 @@ class Lab extends Component {
       spectrumBar,
       frequency,
       shouldOscillate,
+      oscillation,
+      timerCount,
     } = this.props;
     const { emittedLineStepSize, maxPointsForLines } = this.state;
 
@@ -209,7 +205,6 @@ class Lab extends Component {
           className={classes.stage}
           width={stageDimensions.width}
           height={stageDimensions.height}
-          onClick={this.handleCanvasClick}
         >
           <Layer>
             {generateAngles(numberOfLines).map((angle, index) => (
@@ -224,6 +219,8 @@ class Lab extends Component {
                 key={index}
                 isPaused={isPaused}
                 numberOfLines={numberOfLines}
+                oscillation={oscillation}
+                timerCount={timerCount}
               />
             ))}
             {gridLines && (
@@ -279,11 +276,11 @@ const mapStateToProps = ({ layout }) => ({
   timerCount: layout.lab.timerCount,
   elapsedTime: layout.lab.elapsedTime,
   spectrumBar: layout.lab.spectrumBar,
+  oscillation: layout.lab.oscillation,
 });
 
 const mapDispatchToProps = {
   dispatchSetStageDimensions: setStageDimensions,
-  dispatchTogglePause: togglePause,
   dispatchSetChargeOrigin: setChargeOrigin,
   dispatchSetChargeOscillation: setChargeOscillation,
   dispatchSetTimerCount: setTimerCount,

--- a/src/reducers/layout.js
+++ b/src/reducers/layout.js
@@ -46,7 +46,7 @@ const INITIAL_STATE = {
     amplitude: DEFAULT_AMPLITUDE,
     numberOfLines: DEFAULT_NUMBER_OF_LINES,
     frequency: DEFAULT_FREQUENCY,
-    isPaused: false,
+    isPaused: true,
     chargeOrigin: {
       x: DEFAULT_CHARGE_X_POSITION,
       y: DEFAULT_CHARGE_Y_POSITION,


### PR DESCRIPTION
@juancarlosfarah @pyphilia:

- Animation controls are now like in applications 2 and 3.
- Bugs when increasing/decreasing number of lines are fixed. 
- I added a stop button to achieve the effect of stopping an oscillating charge. Unfortunately there is no Material UI icon for a stop button with a circular outline. We could just remove this stop button and its functionality. Not convinced it's adding much.

Let me know what you think and if you encounter any bugs.