### PR TITLE
60/adjust num lines

### DIFF
--- a/src/components/lab/Lab.js
+++ b/src/components/lab/Lab.js
@@ -187,7 +187,6 @@ class Lab extends Component {
       measuringArrowWidth,
       spectrumBar,
       frequency,
-      shouldOscillate,
       oscillation,
       timerCount,
     } = this.props;
@@ -241,7 +240,6 @@ class Lab extends Component {
                 frequency={frequency}
                 stageWidth={stageDimensions.width}
                 stageHeight={stageDimensions.height}
-                shouldOscillate={shouldOscillate}
               />
             )}
             <Circle

--- a/src/components/lab/SpectrumBar.js
+++ b/src/components/lab/SpectrumBar.js
@@ -27,12 +27,7 @@ import {
 } from '../../config/constants';
 import { calculateWavelength } from '../../utils/physics';
 
-const SpectrumBar = ({
-  stageWidth,
-  stageHeight,
-  frequency,
-  shouldOscillate,
-}) => {
+const SpectrumBar = ({ stageWidth, stageHeight, frequency }) => {
   // ref attached to wavelength label (used to detect its width and position it)
   // initialized to APPROXIMATE_WAVELENGTH_LABEL_WIDTH to minimize adjustment/jump after element has been rendered
   const wavelengthLabel = useRef(null);
@@ -209,7 +204,6 @@ const SpectrumBar = ({
       <SpectrumBarMarker
         xPosition={spectrumBarMarkerXPosition}
         yPosition={spectrumBarInitialYPosition}
-        shouldOscillate={shouldOscillate}
       />
     </Group>
   );
@@ -219,7 +213,6 @@ SpectrumBar.propTypes = {
   stageWidth: PropTypes.number.isRequired,
   stageHeight: PropTypes.number.isRequired,
   frequency: PropTypes.number.isRequired,
-  shouldOscillate: PropTypes.bool.isRequired,
 };
 
 export default SpectrumBar;

--- a/src/components/lab/SpectrumBar.js
+++ b/src/components/lab/SpectrumBar.js
@@ -11,9 +11,7 @@ import {
   TOTAL_SPECTRUM_BAR_WIDTH,
   SPECTRUM_BAR_STROKE_COLOR,
   SPECTRUM_BAR_STROKE_WIDTH,
-  INFRARED_BAR_COLOR,
   VISIBLE_LIGHT_COLOR_RANGE,
-  ULTRAVIOLET_BAR_COLOR,
   SPECTRUM_BAR_LABELS_FONT_SIZE,
   INFRARED_BAR_LABEL_COLOR,
   ULTRAVIOLET_BAR_LABEL_COLOR,
@@ -24,6 +22,8 @@ import {
   MIN_DISPLAYED_WAVELENGTH,
   APPROXIMATE_WAVELENGTH_LABEL_WIDTH,
   SPECTRUM_BAR_PADDING,
+  ULTRAVIOLET_COLOR_RANGE,
+  INFRARED_COLOR_RANGE,
 } from '../../config/constants';
 import { calculateWavelength } from '../../utils/physics';
 
@@ -66,7 +66,12 @@ const SpectrumBar = ({ stageWidth, stageHeight, frequency }) => {
         height={SPECTRUM_BAR_HEIGHT}
         stroke={SPECTRUM_BAR_STROKE_COLOR}
         strokeWidth={SPECTRUM_BAR_STROKE_WIDTH}
-        fill={INFRARED_BAR_COLOR}
+        fillLinearGradientStartPoint={{ x: 0, y: 0 }}
+        fillLinearGradientEndPoint={{
+          x: INFRARED_BAR_WIDTH,
+          y: 0,
+        }}
+        fillLinearGradientColorStops={INFRARED_COLOR_RANGE}
       />
       <Rect
         x={spectrumBarInitialXPosition + INFRARED_BAR_WIDTH}
@@ -93,7 +98,12 @@ const SpectrumBar = ({ stageWidth, stageHeight, frequency }) => {
         height={SPECTRUM_BAR_HEIGHT}
         stroke={SPECTRUM_BAR_STROKE_COLOR}
         strokeWidth={SPECTRUM_BAR_STROKE_WIDTH}
-        fill={ULTRAVIOLET_BAR_COLOR}
+        fillLinearGradientStartPoint={{ x: 0, y: 0 }}
+        fillLinearGradientEndPoint={{
+          x: ULTRAVIOLET_BAR_WIDTH,
+          y: 0,
+        }}
+        fillLinearGradientColorStops={ULTRAVIOLET_COLOR_RANGE}
       />
       {/* two text labels for labels inside the spectrum bar */}
       <Text

--- a/src/components/lab/SpectrumBar.js
+++ b/src/components/lab/SpectrumBar.js
@@ -11,9 +11,9 @@ import {
   TOTAL_SPECTRUM_BAR_WIDTH,
   SPECTRUM_BAR_STROKE_COLOR,
   SPECTRUM_BAR_STROKE_WIDTH,
-  INFRARED_COLOR_RANGE,
+  INFRARED_BAR_COLOR,
   VISIBLE_LIGHT_COLOR_RANGE,
-  ULTRAVIOLET_COLOR_RANGE,
+  ULTRAVIOLET_BAR_COLOR,
   SPECTRUM_BAR_LABELS_FONT_SIZE,
   INFRARED_BAR_LABEL_COLOR,
   ULTRAVIOLET_BAR_LABEL_COLOR,
@@ -71,12 +71,7 @@ const SpectrumBar = ({
         height={SPECTRUM_BAR_HEIGHT}
         stroke={SPECTRUM_BAR_STROKE_COLOR}
         strokeWidth={SPECTRUM_BAR_STROKE_WIDTH}
-        fillLinearGradientStartPoint={{ x: 0, y: 0 }}
-        fillLinearGradientEndPoint={{
-          x: INFRARED_BAR_WIDTH,
-          y: 0,
-        }}
-        fillLinearGradientColorStops={INFRARED_COLOR_RANGE}
+        fill={INFRARED_BAR_COLOR}
       />
       <Rect
         x={spectrumBarInitialXPosition + INFRARED_BAR_WIDTH}
@@ -103,12 +98,7 @@ const SpectrumBar = ({
         height={SPECTRUM_BAR_HEIGHT}
         stroke={SPECTRUM_BAR_STROKE_COLOR}
         strokeWidth={SPECTRUM_BAR_STROKE_WIDTH}
-        fillLinearGradientStartPoint={{ x: 0, y: 0 }}
-        fillLinearGradientEndPoint={{
-          x: ULTRAVIOLET_BAR_WIDTH,
-          y: 0,
-        }}
-        fillLinearGradientColorStops={ULTRAVIOLET_COLOR_RANGE}
+        fill={ULTRAVIOLET_BAR_COLOR}
       />
       {/* two text labels for labels inside the spectrum bar */}
       <Text

--- a/src/components/lab/SpectrumBarMarker.js
+++ b/src/components/lab/SpectrumBarMarker.js
@@ -10,8 +10,8 @@ import {
   SPECTRUM_BAR_MARKER_TRIANGLE_HEIGHT,
 } from '../../config/constants';
 
-const SpectrumBarMarker = ({ xPosition, yPosition, shouldOscillate }) => {
-  if (!shouldOscillate || xPosition === 0) {
+const SpectrumBarMarker = ({ xPosition, yPosition }) => {
+  if (xPosition === 0) {
     return null;
   }
 
@@ -68,7 +68,6 @@ const SpectrumBarMarker = ({ xPosition, yPosition, shouldOscillate }) => {
 SpectrumBarMarker.propTypes = {
   yPosition: PropTypes.number.isRequired,
   xPosition: PropTypes.number.isRequired,
-  shouldOscillate: PropTypes.bool.isRequired,
 };
 
 export default SpectrumBarMarker;

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -109,7 +109,7 @@ export const SPECTRUM_BAR_HEIGHT = 50;
 export const SPECTRUM_BAR_STROKE_COLOR = 'black';
 export const SPECTRUM_BAR_STROKE_WIDTH = 0.5;
 // css gradient, values from 0 to 1
-export const INFRARED_BAR_COLOR = 'black';
+export const INFRARED_COLOR_RANGE = [0, 'black', 0.9, 'black', 1, 'red'];
 export const VISIBLE_LIGHT_COLOR_RANGE = [
   0,
   'red',
@@ -126,7 +126,7 @@ export const VISIBLE_LIGHT_COLOR_RANGE = [
   1,
   'violet',
 ];
-export const ULTRAVIOLET_BAR_COLOR = 'black';
+export const ULTRAVIOLET_COLOR_RANGE = [0, 'violet', 0.1, 'black'];
 export const SPECTRUM_BAR_LABELS_FONT_SIZE = 16;
 export const INFRARED_BAR_LABEL_COLOR = 'white';
 export const ULTRAVIOLET_BAR_LABEL_COLOR = 'white';

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -109,7 +109,7 @@ export const SPECTRUM_BAR_HEIGHT = 50;
 export const SPECTRUM_BAR_STROKE_COLOR = 'black';
 export const SPECTRUM_BAR_STROKE_WIDTH = 0.5;
 // css gradient, values from 0 to 1
-export const INFRARED_COLOR_RANGE = [0, 'darkred', 1, 'red'];
+export const INFRARED_BAR_COLOR = 'black';
 export const VISIBLE_LIGHT_COLOR_RANGE = [
   0,
   'red',
@@ -126,17 +126,17 @@ export const VISIBLE_LIGHT_COLOR_RANGE = [
   1,
   'violet',
 ];
-export const ULTRAVIOLET_COLOR_RANGE = [0, 'violet', 1, 'white'];
+export const ULTRAVIOLET_BAR_COLOR = 'black';
 export const SPECTRUM_BAR_LABELS_FONT_SIZE = 16;
 export const INFRARED_BAR_LABEL_COLOR = 'white';
-export const ULTRAVIOLET_BAR_LABEL_COLOR = 'black';
+export const ULTRAVIOLET_BAR_LABEL_COLOR = 'white';
 export const SPECTRUM_BAR_PADDING = 8;
 export const WAVELENGTH_LABELS_X_AXIS_ADJUSTMENT_FACTOR = 10;
 export const WAVELENGTH_LABELS_Y_AXIS_ADJUSTMENT_FACTOR = 5;
 export const APPROXIMATE_WAVELENGTH_LABEL_WIDTH = 120;
 
 // spectrum bar marker constants
-export const SPECTRUM_BAR_MARKER_COLOR = 'black';
+export const SPECTRUM_BAR_MARKER_COLOR = 'red';
 export const SPECTRUM_BAR_MARKER_TRIANGLE_STROKE_WIDTH = 1;
 export const SPECTRUM_BAR_MARKER_LINE_STROKE_WIDTH = 2;
 export const SPECTRUM_BAR_MARKER_TRIANGLE_BASE = 16;

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -21,10 +21,10 @@ export const DEFAULT_AMPLITUDE = 20;
 export const MIN_AMPLITUDE = 0;
 export const MAX_AMPLITUDE = 40;
 export const AMPLITUDE_STEP = 5;
-export const DEFAULT_NUMBER_OF_LINES = 6;
-export const MIN_NUMBER_OF_LINES = 2;
-export const MAX_NUMBER_OF_LINES = 20;
-export const NUMBER_OF_LINES_STEP = 2;
+export const DEFAULT_NUMBER_OF_LINES = 12;
+export const MIN_NUMBER_OF_LINES = 4;
+export const MAX_NUMBER_OF_LINES = 40;
+export const NUMBER_OF_LINES_STEP = 4;
 export const DEFAULT_TENSION = 0.1;
 export const LINE_STEP_SIZE = 5;
 
@@ -144,10 +144,10 @@ export const SPECTRUM_BAR_MARKER_TRIANGLE_HEIGHT = 8;
 
 // numOfLines should be >= 2
 export const generateAngles = (numOfLines) => {
-  const firstQuadrantAngles = new Array(numOfLines / 2)
+  const firstQuadrantAngles = new Array(numOfLines / 4)
     .fill()
     .map(
-      (emptyElement, index) => (Math.PI / 2 / (numOfLines / 2)) * (index + 1),
+      (emptyElement, index) => (Math.PI / 2 / (numOfLines / 4)) * (index + 1),
     );
 
   // generating angles for remaining quadrants is easy: just add 90deg (PI / 2) to each angle in previous quadrant


### PR DESCRIPTION
fairly small fixes based on feedback. spectrum bar now looks like this:

![Screen Shot 2021-05-26 at 12 18 59 PM](https://user-images.githubusercontent.com/19311953/119643872-9306f300-be1c-11eb-9e9f-36e91d7800c4.png)

A small issue might be: when the simulation is paused and the frequency is changed, the spectrum bar marker—now visible even when the simulation is paused—will jump to the new wavelength, even though the application is paused at the old wavelength. The user has to click play for the charge to restart oscillating at the new wavelength. There are possible fixes for this but I didn't want to implement them now because: (1) They might actually want this feature, i.e. we changed the frequency, so the wavelength should change, (2) It might not be that much of an issue (e.g. frequency is typically changed when charge is already oscillating)